### PR TITLE
Fix bug when the autograder crushes if the 'result' of a previous submission is None.

### DIFF
--- a/src/gspack/environment.py
+++ b/src/gspack/environment.py
@@ -102,6 +102,11 @@ class Environment:
         max_previous_score = 0
 
         for previous_submission in submission_metadata['previous_submissions']:
+            if previous_submission["results"] is None:
+                # it happens sometimes when the autograder failed to
+                # produce any output at all during one of the previous submissions
+                # due to a bug in the autograder itself.
+                continue
             results = previous_submission["results"]
             extra_data = results.get('extra_data', None)
             if extra_data is not None and extra_data["success"] and not extra_data["pretest"]:


### PR DESCRIPTION
It happens sometimes when the autograder failed to produce any output at all during one of the previous submissions due to a bug in the autograder itself. See [my issue](https://github.com/aksholokhov/gspack/issues/8) regarding it.